### PR TITLE
implement ProjectCounterPage with session tracking

### DIFF
--- a/src/StitchTrack.Application/ViewModels/ProjectCounterViewModel.cs
+++ b/src/StitchTrack.Application/ViewModels/ProjectCounterViewModel.cs
@@ -1,0 +1,358 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using StitchTrack.Application.Commands;
+using StitchTrack.Application.Interfaces;
+using StitchTrack.Domain.Entities;
+using StitchTrack.Domain.Interfaces;
+
+namespace StitchTrack.Application.ViewModels;
+
+/// <summary>
+/// ViewModel for ProjectCounterPage.
+/// Handles counting rows against an existing project, with optional session tracking.
+///
+/// Flow:
+/// - User taps Play  → starts visual timer + creates in-memory Session
+/// - User taps Pause → pauses visual timer (session keeps its start time)
+/// - Save Progress   → saves Project.CurrentCount only, stays on page
+/// - End Session     → saves Session + Project.CurrentCount, navigates back
+/// </summary>
+public class ProjectCounterViewModel : INotifyPropertyChanged
+{
+    private readonly IProjectRepository _projectRepository;
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IDialogService _dialogService;
+    private readonly INavigationService _navigationService;
+
+    private Project? _project;
+    private Session? _currentSession;
+    private bool _isSessionRunning;
+    private TimeSpan _sessionDuration;
+    private bool _notesExpanded;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    // Project ID set from Shell navigation query parameter
+    public Guid ProjectId { get; set; }
+
+    // ─── Project properties ──────────────────────────────────────
+
+    public string ProjectName => _project?.Name ?? "Project";
+    public string? ColorHex => _project?.ColorHex;
+    public int CurrentCount => _project?.CurrentCount ?? 0;
+    public int? TotalRows => _project?.TotalRows;
+    public string? Notes => _project?.Notes;
+    public bool HasNotes => !string.IsNullOrWhiteSpace(Notes);
+    public bool HasTotalRows => TotalRows.HasValue && TotalRows > 0;
+
+    // ─── Progress ────────────────────────────────────────────────
+
+    // Progress 0.0–1.0 for the progress bar
+    public double ProgressValue =>
+        HasTotalRows && TotalRows!.Value > 0
+            ? Math.Min((double)CurrentCount / TotalRows.Value, 1.0)
+            : 0;
+
+    public string ProgressText =>
+        HasTotalRows
+            ? $"{CurrentCount} / {TotalRows} rows"
+            : $"Row {CurrentCount}";
+
+    public string ProgressPercentage =>
+        HasTotalRows && TotalRows!.Value > 0
+            ? $"{(int)(ProgressValue * 100)}% done"
+            : string.Empty;
+
+    // ─── Session / Timer ─────────────────────────────────────────
+
+    public bool IsSessionRunning
+    {
+        get => _isSessionRunning;
+        private set
+        {
+            if (_isSessionRunning != value)
+            {
+                _isSessionRunning = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SessionButtonText));
+                OnPropertyChanged(nameof(SessionButtonIcon));
+            }
+        }
+    }
+
+    // Timer duration formatted for display e.g. "1h 23m" or "4m 12s"
+    public string SessionTimerText => FormatDuration(_sessionDuration);
+
+    public string SessionButtonText => IsSessionRunning ? "PAUSE" : "START SESSION";
+    public string SessionButtonIcon => IsSessionRunning ? "pause.svg" : "play.svg";
+
+    // ─── Notes expand/collapse ───────────────────────────────────
+
+    public bool NotesCanExpand => HasNotes && (Notes?.Length ?? 0) > 150;
+    public int NotesMaxLines => _notesExpanded ? int.MaxValue : 3;
+    public string NotesToggleText => _notesExpanded ? "See less ▲" : "See all notes ▼";
+
+    // ─── Commands ────────────────────────────────────────────────
+
+    public ICommand IncrementCommand { get; }
+    public ICommand DecrementCommand { get; }
+    public ICommand ResetCommand { get; }
+    public ICommand ToggleSessionCommand { get; }
+    public ICommand SaveProgressCommand { get; }
+    public ICommand EndSessionCommand { get; }
+    public ICommand ToggleNotesCommand { get; }
+    public ICommand UndoCommand { get; }
+
+    // Set by the Page to handle navigation back
+    public Func<Task>? OnNavigateBack { get; set; }
+
+    public ProjectCounterViewModel(
+        IProjectRepository projectRepository,
+        ISessionRepository sessionRepository,
+        IDialogService dialogService,
+        INavigationService navigationService)
+    {
+        _projectRepository = projectRepository ?? throw new ArgumentNullException(nameof(projectRepository));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+
+        IncrementCommand = new RelayCommand(OnIncrement);
+        DecrementCommand = new RelayCommand(OnDecrement);
+        ResetCommand = new RelayCommand(OnReset);
+        ToggleSessionCommand = new RelayCommand(OnToggleSession);
+        SaveProgressCommand = new RelayCommand(OnSaveProgress);
+        EndSessionCommand = new RelayCommand(OnEndSession);
+        ToggleNotesCommand = new RelayCommand(OnToggleNotes);
+        UndoCommand = new RelayCommand(OnUndo);
+
+        System.Diagnostics.Debug.WriteLine("✅ ProjectCounterViewModel created");
+    }
+
+    /// <summary>
+    /// Loads the project from the database using ProjectId set by navigation.
+    /// </summary>
+    public async Task LoadProjectAsync()
+    {
+        try
+        {
+            System.Diagnostics.Debug.WriteLine($"📂 Loading project for counter: {ProjectId}");
+
+            _project = await _projectRepository.GetByIdWithoutHistoryAsync(ProjectId).ConfigureAwait(false);
+
+            if (_project == null)
+            {
+                System.Diagnostics.Debug.WriteLine($"⚠️ Project not found: {ProjectId}");
+                await _dialogService.ShowAlertAsync("Error", "Project not found").ConfigureAwait(false);
+                return;
+            }
+
+            OnPropertyChanged(string.Empty);
+            System.Diagnostics.Debug.WriteLine($"✅ Project loaded for counter: {_project.Name} (row {_project.CurrentCount})");
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            System.Diagnostics.Debug.WriteLine($"❌ Error loading project: {ex.Message}");
+            await _dialogService.ShowAlertAsync("Error", "Could not load project").ConfigureAwait(false);
+        }
+    }
+
+    // ─── Counter actions ─────────────────────────────────────────
+
+    private void OnIncrement()
+    {
+        if (_project == null) return;
+
+        // Entity method handles history recording
+        _project.IncrementCount();
+        NotifyCounterChanged();
+    }
+
+    private void OnDecrement()
+    {
+        if (_project == null) return;
+
+        _project.DecrementCount();
+        NotifyCounterChanged();
+    }
+
+    private async void OnReset()
+    {
+        if (_project == null) return;
+
+        // Reset is destructive in context — confirm before clearing progress
+        var confirmed = await _dialogService.ShowConfirmAsync(
+            title: "Reset Counter?",
+            message: "This will reset the counter to 0. Your saved progress won't be affected until you save.",
+            accept: "Reset",
+            cancel: "Cancel"
+        ).ConfigureAwait(true);
+
+        if (!confirmed) return;
+
+        _project.ResetCount();
+        NotifyCounterChanged();
+    }
+
+    /// <summary>
+    /// Notifies all counter-related properties so the UI updates.
+    /// </summary>
+    private void NotifyCounterChanged()
+    {
+        OnPropertyChanged(nameof(CurrentCount));
+        OnPropertyChanged(nameof(ProgressValue));
+        OnPropertyChanged(nameof(ProgressText));
+        OnPropertyChanged(nameof(ProgressPercentage));
+    }
+
+    // ─── Session actions ─────────────────────────────────────────
+
+    private void OnToggleSession()
+    {
+        if (IsSessionRunning)
+            PauseSession();
+        else
+            StartSession();
+    }
+
+    private void StartSession()
+    {
+        if (_project == null) return;
+
+        // Create session in memory — only persisted on EndSession
+        _currentSession ??= Session.StartSession(_project.Id, _project.CurrentCount);
+
+        IsSessionRunning = true;
+        System.Diagnostics.Debug.WriteLine($"▶️ Session started for {_project.Name}");
+    }
+
+    private void PauseSession()
+    {
+        IsSessionRunning = false;
+        System.Diagnostics.Debug.WriteLine("⏸️ Session paused");
+    }
+
+    /// <summary>
+    /// Updates the session timer display — called by the Page's timer tick.
+    /// Kept here so the ViewModel controls the formatted display string.
+    /// </summary>
+    public void UpdateSessionTimer(TimeSpan elapsed)
+    {
+        _sessionDuration = elapsed;
+        OnPropertyChanged(nameof(SessionTimerText));
+    }
+
+    // ─── Save & End ──────────────────────────────────────────────
+
+    private void OnSaveProgress() => _ = SaveProgressAsync();
+    private void OnEndSession() => _ = EndSessionAsync();
+
+    /// <summary>
+    /// Saves the current count to the database.
+    /// Stays on the page — session keeps running.
+    /// </summary>
+    private async Task SaveProgressAsync()
+    {
+        if (_project == null) return;
+
+        try
+        {
+            // Direct SQL update — bypasses change tracker entirely
+            await _projectRepository.UpdateCountAsync(
+                _project.Id,
+                _project.CurrentCount,
+                DateTime.UtcNow
+            ).ConfigureAwait(false);
+
+            await _dialogService.ShowToastAsync($"Progress saved — row {_project.CurrentCount}").ConfigureAwait(false);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            System.Diagnostics.Debug.WriteLine($"❌ Error saving progress: {ex.Message}");
+            await _dialogService.ShowAlertAsync("Save Failed", "Could not save progress.").ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Ends the session: saves count + session record, then navigates back.
+    /// If no session was started, just saves the count and goes back.
+    /// </summary>
+    private async Task EndSessionAsync()
+    {
+        if (_project == null) return;
+
+        try
+        {
+            // Direct SQL update — bypasses change tracker entirely
+            await _projectRepository.UpdateCountAsync(
+                _project.Id,
+                _project.CurrentCount,
+                DateTime.UtcNow
+            ).ConfigureAwait(false);
+
+            // Save the session if one was started
+            if (_currentSession != null)
+            {
+                _currentSession.EndSession(_project.CurrentCount);
+                await _sessionRepository.AddAsync(_currentSession).ConfigureAwait(false);
+                await _sessionRepository.SaveChangesAsync().ConfigureAwait(false);
+
+                System.Diagnostics.Debug.WriteLine($"✅ Session ended: {_currentSession.DurationSeconds}s, rows {_currentSession.StartingRowCount}→{_currentSession.EndingRowCount}");
+            }
+
+            IsSessionRunning = false;
+
+            await _dialogService.ShowToastAsync($"Session saved — row {_project.CurrentCount}").ConfigureAwait(false);
+            await _navigationService.GoBackAsync().ConfigureAwait(false);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            System.Diagnostics.Debug.WriteLine($"❌ Error ending session: {ex.Message}");
+            await _dialogService.ShowAlertAsync("Error", "Could not save session.").ConfigureAwait(false);
+        }
+    }
+
+    // ─── Notes ───────────────────────────────────────────────────
+
+    private void OnToggleNotes()
+    {
+        _notesExpanded = !_notesExpanded;
+        OnPropertyChanged(nameof(NotesMaxLines));
+        OnPropertyChanged(nameof(NotesToggleText));
+    }
+
+    private void OnUndo()
+    {
+        if (_project == null) return;
+
+        var undone = _project.UndoLastChange();
+        if (undone)
+            NotifyCounterChanged();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalHours >= 1)
+            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
+
+        if (duration.TotalMinutes >= 1)
+            return $"{duration.Minutes}m {duration.Seconds}s";
+
+        return $"{duration.Seconds}s";
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/StitchTrack.Application/ViewModels/SingleProjectViewModel.cs
+++ b/src/StitchTrack.Application/ViewModels/SingleProjectViewModel.cs
@@ -282,10 +282,12 @@ public class SingleProjectViewModel : INotifyPropertyChanged
         // TODO: Implement sync
     }
 
-    private void OnContinueCounting()
+    private async void OnContinueCounting()
     {
-        System.Diagnostics.Debug.WriteLine("▶️ Continue Counting tapped");
-        // TODO: Navigate to counter page with project context
+        if (_project == null) return;
+        await _navigationService.NavigateToAsync(
+            $"ProjectCounterPage?ProjectId={_project.Id}"
+        ).ConfigureAwait(false);
     }
 
     private void OnViewPattern()

--- a/src/StitchTrack.Domain/Interfaces/IProjectRepository.cs
+++ b/src/StitchTrack.Domain/Interfaces/IProjectRepository.cs
@@ -19,6 +19,12 @@ public interface IProjectRepository
     Task<Project?> GetByIdAsync(Guid id);
 
     /// <summary>
+    /// Gets a project by ID without loading CounterHistory entries.
+    /// Use for the counter page where history tracking causes EF state conflicts.
+    /// </summary>
+    Task<Project?> GetByIdWithoutHistoryAsync(Guid id);
+
+    /// <summary>
     /// Gets all non-archived projects for the current user.
     /// </summary>
     Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid? userId = null);
@@ -32,6 +38,10 @@ public interface IProjectRepository
     /// Updates an existing project.
     /// </summary>
     Task UpdateAsync(Project project);
+    /// <summary>
+    /// Updates only the Count and UpdatedAt fields of a project.
+    /// </summary>
+    Task UpdateCountAsync(Guid projectId, int newCount, DateTime updatedAt);
 
     /// <summary>
     /// Soft delete — sets IsArchived = true. Project remains in the database.

--- a/src/StitchTrack.Domain/Interfaces/ISessionRepository.cs
+++ b/src/StitchTrack.Domain/Interfaces/ISessionRepository.cs
@@ -1,0 +1,55 @@
+namespace StitchTrack.Domain.Interfaces;
+
+using StitchTrack.Domain.Entities;
+
+/// <summary>
+/// Repository interface for Session entity.
+/// Handles persistence of work sessions tied to projects.
+/// </summary>
+public interface ISessionRepository
+{
+    // ─── Phase 1 ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Adds a new session record to the database context.
+    /// Call SaveChangesAsync to persist.
+    /// </summary>
+    Task AddAsync(Session session);
+
+    /// <summary>
+    /// Persists all pending changes to the database.
+    /// </summary>
+    Task<int> SaveChangesAsync();
+
+    // ─── Phase 2 / Stats page ───────────────────────────────────
+
+    /// <summary>
+    /// Returns all sessions for a given project, ordered newest first.
+    /// Used for session history on SingleProjectPage.
+    /// </summary>
+    Task<IEnumerable<Session>> GetByProjectIdAsync(Guid projectId);
+
+    /// <summary>
+    /// Returns all sessions across all projects for the current user.
+    /// Used for the Stats page overview.
+    /// </summary>
+    Task<IEnumerable<Session>> GetAllAsync();
+
+    /// <summary>
+    /// Returns sessions that started within the given date range.
+    /// Used for Stats page filters (Today, This Week, This Month, All).
+    /// </summary>
+    Task<IEnumerable<Session>> GetByDateRangeAsync(DateTime fromDate, DateTime toDate);
+
+    /// <summary>
+    /// Returns the most recent N sessions across all projects.
+    /// Used for "Recent Sessions" list on the Stats page.
+    /// </summary>
+    Task<IEnumerable<Session>> GetRecentAsync(int count = 10);
+
+    /// <summary>
+    /// Deletes all sessions belonging to a project.
+    /// Called before hard-deleting a project.
+    /// </summary>
+    Task DeleteByProjectIdAsync(Guid projectId);
+}

--- a/src/StitchTrack.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/StitchTrack.Infrastructure/Repositories/ProjectRepository.cs
@@ -46,7 +46,7 @@ public class ProjectRepository : IProjectRepository
     public async Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid? userId = null)
     {
         var query = _context.Projects
-        .AsNoTracking()  
+        .AsNoTracking()
         .Where(p => !p.IsArchived);
 
         if (userId.HasValue)
@@ -68,7 +68,7 @@ public class ProjectRepository : IProjectRepository
     public async Task<IEnumerable<Project>> GetArchivedProjectsAsync(Guid? userId = null)
     {
         var query = _context.Projects
-        .AsNoTracking()  
+        .AsNoTracking()
         .Where(p => p.IsArchived);
 
         if (userId.HasValue)

--- a/src/StitchTrack.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/StitchTrack.Infrastructure/Repositories/ProjectRepository.cs
@@ -35,10 +35,19 @@ public class ProjectRepository : IProjectRepository
             .ConfigureAwait(false);
     }
 
+    public async Task<Project?> GetByIdWithoutHistoryAsync(Guid id)
+    {
+        return await _context.Projects
+            .Include(p => p.Sessions)
+            .FirstOrDefaultAsync(p => p.Id == id)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid? userId = null)
     {
         var query = _context.Projects
-            .Where(p => !p.IsArchived);
+        .AsNoTracking()  
+        .Where(p => !p.IsArchived);
 
         if (userId.HasValue)
         {
@@ -59,7 +68,8 @@ public class ProjectRepository : IProjectRepository
     public async Task<IEnumerable<Project>> GetArchivedProjectsAsync(Guid? userId = null)
     {
         var query = _context.Projects
-            .Where(p => p.IsArchived);
+        .AsNoTracking()  
+        .Where(p => p.IsArchived);
 
         if (userId.HasValue)
         {
@@ -80,10 +90,31 @@ public class ProjectRepository : IProjectRepository
     {
         ArgumentNullException.ThrowIfNull(project);
 
-        _context.Projects.Update(project);
-        System.Diagnostics.Debug.WriteLine($"🔄 Project updated: {project.Name}");
+        // If the project was loaded via GetByIdAsync in this same DbContext instance,
+        // EF Core is already tracking it and knows what changed.
+        // Calling Update() would override child entity states (e.g. Added → Modified)
+        // causing INSERT to become UPDATE on rows that don't exist yet.
+        var entry = _context.Entry(project);
+        if (entry.State == EntityState.Detached)
+        {
+            // Only attach and mark modified if not already tracked
+            _context.Projects.Update(project);
+        }
 
+        System.Diagnostics.Debug.WriteLine($"🔄 Project updated: {project.Name}");
         await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    public async Task UpdateCountAsync(Guid projectId, int newCount, DateTime updatedAt)
+    {
+        await _context.Projects
+            .Where(p => p.Id == projectId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(p => p.CurrentCount, newCount)
+                .SetProperty(p => p.UpdatedAt, updatedAt))
+            .ConfigureAwait(false);
+
+        System.Diagnostics.Debug.WriteLine($"💾 Count updated to {newCount}");
     }
 
     /// <summary>

--- a/src/StitchTrack.Infrastructure/Repositories/SessionRepository.cs
+++ b/src/StitchTrack.Infrastructure/Repositories/SessionRepository.cs
@@ -1,0 +1,104 @@
+using Microsoft.EntityFrameworkCore;
+using StitchTrack.Domain.Entities;
+using StitchTrack.Domain.Interfaces;
+using StitchTrack.Infrastructure.Data;
+
+namespace StitchTrack.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core implementation of ISessionRepository.
+/// </summary>
+public class SessionRepository : ISessionRepository
+{
+    private readonly AppDbContext _context;
+
+    public SessionRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task AddAsync(Session session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        await _context.Sessions.AddAsync(session).ConfigureAwait(false);
+        System.Diagnostics.Debug.WriteLine($"📝 Session added to context: {session.Id}");
+    }
+
+    public async Task<int> SaveChangesAsync()
+    {
+        // Detach stale CounterHistory entries tracked from previous page loads
+        // to prevent EF trying to UPDATE rows that were never inserted in this session
+        var staleHistoryEntries = _context.ChangeTracker
+            .Entries<CounterHistory>()
+            .Where(e => e.State == EntityState.Modified)
+            .ToList();
+
+        foreach (var entry in staleHistoryEntries)
+            entry.State = EntityState.Detached;
+
+        var changes = await _context.SaveChangesAsync().ConfigureAwait(false);
+        System.Diagnostics.Debug.WriteLine($"💾 Saved {changes} session changes");
+        return changes;
+    }
+
+    /// <summary>
+    /// Returns all sessions for a project, newest first.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetByProjectIdAsync(Guid projectId)
+    {
+        return await _context.Sessions
+            .Where(s => s.ProjectId == projectId)
+            .OrderByDescending(s => s.StartedAt)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns all sessions across all projects.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetAllAsync()
+    {
+        return await _context.Sessions
+            .OrderByDescending(s => s.StartedAt)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns sessions within a date range for Stats page filters.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetByDateRangeAsync(DateTime fromDate, DateTime toDate)
+    {
+        return await _context.Sessions
+            .Where(s => s.StartedAt >= fromDate && s.StartedAt <= toDate)
+            .OrderByDescending(s => s.StartedAt)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the most recent N sessions for the Recent Sessions list.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetRecentAsync(int count = 10)
+    {
+        return await _context.Sessions
+            .OrderByDescending(s => s.StartedAt)
+            .Take(count)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes all sessions for a project — called before hard-deleting a project.
+    /// </summary>
+    public async Task DeleteByProjectIdAsync(Guid projectId)
+    {
+        var sessions = await _context.Sessions
+            .Where(s => s.ProjectId == projectId)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        _context.Sessions.RemoveRange(sessions);
+        System.Diagnostics.Debug.WriteLine($"🗑️ Deleted {sessions.Count} sessions for project {projectId}");
+    }
+}

--- a/src/StitchTrack.MAUI/AppShell.xaml.cs
+++ b/src/StitchTrack.MAUI/AppShell.xaml.cs
@@ -10,6 +10,7 @@ public partial class AppShell : Shell
 
         // Register child/modal pages only
         Routing.RegisterRoute("SingleProjectPage", typeof(SingleProjectPage));
+        Routing.RegisterRoute("ProjectCounterPage", typeof(ProjectCounterPage));
 
         // Handle tab navigation
         Navigating += OnShellNavigating;
@@ -21,7 +22,8 @@ public partial class AppShell : Shell
 
         // Prevent Shell from restoring cached child pages when switching tabs
         if (target.Contains("//projects", StringComparison.OrdinalIgnoreCase) &&
-            target.Contains("SingleProjectPage", StringComparison.OrdinalIgnoreCase))
+             (target.Contains("SingleProjectPage", StringComparison.OrdinalIgnoreCase) ||
+             target.Contains("ProjectCounterPage", StringComparison.OrdinalIgnoreCase)))
         {
             System.Diagnostics.Debug.WriteLine("⛔ Blocked navigation to cached child page");
             e.Cancel();

--- a/src/StitchTrack.MAUI/MauiProgram.cs
+++ b/src/StitchTrack.MAUI/MauiProgram.cs
@@ -47,6 +47,7 @@ public static class MauiProgram
         // REPOSITORIES
         builder.Services.AddScoped<IProjectRepository, ProjectRepository>();
         builder.Services.AddScoped<IAppSettingsRepository, AppSettingsRepository>();
+        builder.Services.AddScoped<ISessionRepository, SessionRepository>();
 
         // SERVICES
         builder.Services.AddSingleton<IDialogService, MauiDialogService>();
@@ -57,6 +58,7 @@ public static class MauiProgram
         builder.Services.AddTransient<QuickCounterViewModel>();
         builder.Services.AddTransient<ProjectsViewModel>();
         builder.Services.AddTransient<SingleProjectViewModel>();
+        builder.Services.AddTransient<ProjectCounterViewModel>();
         // TODO: Add other ViewModels as we create them
         // builder.Services.AddTransient<SessionViewModel>();
         // builder.Services.AddTransient<SettingsViewModel>();
@@ -65,6 +67,7 @@ public static class MauiProgram
         builder.Services.AddTransient<QuickCounterPage>();
         builder.Services.AddTransient<ProjectsPage>();
         builder.Services.AddTransient<SingleProjectPage>();
+        builder.Services.AddTransient<ProjectCounterPage>();
         // TODO: Add other Pages as we create them
         // builder.Services.AddTransient<SessionPage>();
         // builder.Services.AddTransient<SettingsPage>();

--- a/src/StitchTrack.MAUI/StitchTrack.MAUI.csproj
+++ b/src/StitchTrack.MAUI/StitchTrack.MAUI.csproj
@@ -91,6 +91,9 @@
 	  <MauiXaml Update="Views\ExportPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\ProjectCounterPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\QuickCounterPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/src/StitchTrack.MAUI/Views/ProjectCounterPage.xaml
+++ b/src/StitchTrack.MAUI/Views/ProjectCounterPage.xaml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:StitchTrack.Application.ViewModels;assembly=StitchTrack.Application"
+             x:Class="StitchTrack.MAUI.Views.ProjectCounterPage"
+             x:DataType="viewModels:ProjectCounterViewModel"
+             BackgroundColor="{AppThemeBinding Light={StaticResource LightPageBackground}, Dark={StaticResource DarkPageBackground}}"
+             Shell.NavBarIsVisible="False">
+
+  <Grid RowDefinitions="Auto,Auto,*">
+
+    <!-- TOP BAR: Logo only — matches SingleProjectPage pattern -->
+    <Grid Grid.Row="0"
+          BackgroundColor="{AppThemeBinding Light={StaticResource LightAppBackground}, Dark={StaticResource DarkAppBackground}}"
+          Padding="30,30">
+
+      <Image Source="logo.svg"
+             HeightRequest="35"
+             HorizontalOptions="Start"
+             Aspect="AspectFit" />
+
+    </Grid>
+
+    <!-- ============================================ -->
+    <!-- SCROLLABLE CONTENT                           -->
+    <!-- ============================================ -->
+    <ScrollView Grid.Row="2">
+
+      <VerticalStackLayout Spacing="0" Padding="16">
+
+        <!-- SUB-HEADER: Project name + color dot -->
+        <Grid Grid.Row="1"
+              BackgroundColor="{AppThemeBinding Light={StaticResource LightAppBackground}, Dark={StaticResource DarkAppBackground}}"
+              Padding="20,0,20,16">
+
+          <HorizontalStackLayout Spacing="10"
+                                 HorizontalOptions="Start"
+                                 VerticalOptions="Center">
+
+            <Border WidthRequest="12"
+                    HeightRequest="12"
+                    StrokeThickness="0"
+                    BackgroundColor="{Binding ColorHex}"
+                    VerticalOptions="Center">
+              <Border.StrokeShape>
+                <RoundRectangle CornerRadius="6" />
+              </Border.StrokeShape>
+            </Border>
+
+            <Label Text="{Binding ProjectName}"
+                   Style="{StaticResource HeaderTitle}"
+                   FontSize="16" />
+
+          </HorizontalStackLayout>
+
+        </Grid>
+
+        <!-- ============================================ -->
+        <!-- SESSION CARD                                 -->
+        <!-- ============================================ -->
+        <Border Padding="16,14"
+                Margin="0,16,0,0"
+                StrokeThickness="0"
+                BackgroundColor="{AppThemeBinding Light={StaticResource LightCardBackground}, Dark={StaticResource DarkCardBackground}}">
+
+          <Border.StrokeShape>
+            <RoundRectangle CornerRadius="12" />
+          </Border.StrokeShape>
+
+          <Grid ColumnDefinitions="*,Auto"
+                ColumnSpacing="12">
+
+            <!-- Timer display -->
+            <VerticalStackLayout Grid.Column="0"
+                                 Spacing="2"
+                                 VerticalOptions="Center">
+
+              <Label Text="SESSION"
+                     FontFamily="MontserratSemiBold"
+                     FontSize="11"
+                     TextColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark={StaticResource DarkTextSecondary}}"
+                     Opacity="0.7" />
+
+              <Label Text="{Binding SessionTimerText}"
+                     FontFamily="MontserratBold"
+                     FontSize="28"
+                     TextColor="{AppThemeBinding Light={StaticResource LightTextPrimary}, Dark={StaticResource DarkTextPrimary}}" />
+
+            </VerticalStackLayout>
+
+            <!-- Play/Pause button -->
+            <Border Grid.Column="1"
+                    Padding="16,10"
+                    StrokeThickness="0"
+                    BackgroundColor="{StaticResource ButtonSecondary}"
+                    VerticalOptions="Center">
+              <Border.StrokeShape>
+                <RoundRectangle CornerRadius="10" />
+              </Border.StrokeShape>
+              <Border.GestureRecognizers>
+                <TapGestureRecognizer Command="{Binding ToggleSessionCommand}" />
+              </Border.GestureRecognizers>
+
+              <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
+                <Image x:Name="SessionIcon"
+                       Source="{Binding SessionButtonIcon}"
+                       WidthRequest="16"
+                       HeightRequest="16"
+                       VerticalOptions="Center">
+                  <Image.Behaviors>
+                    <toolkit:IconTintColorBehavior TintColor="White" />
+                  </Image.Behaviors>
+                </Image>
+                <Label Text="{Binding SessionButtonText}"
+                       FontFamily="MontserratSemiBold"
+                       FontSize="13"
+                       TextColor="White"
+                       VerticalOptions="Center" />
+              </HorizontalStackLayout>
+            </Border>
+
+          </Grid>
+
+        </Border>
+
+        <!-- ============================================ -->
+        <!-- COUNTER CARD                                 -->
+        <!-- ============================================ -->
+        <Border Padding="20"
+                Margin="0,16,0,0"
+                StrokeThickness="0"
+                BackgroundColor="{AppThemeBinding Light={StaticResource LightCardBackground}, Dark={StaticResource DarkCardBackground}}">
+
+          <Border.StrokeShape>
+            <RoundRectangle CornerRadius="12" />
+          </Border.StrokeShape>
+
+          <VerticalStackLayout Spacing="16">
+
+            <!-- Row count display -->
+            <Label Text="{Binding CurrentCount}"
+                   Style="{StaticResource CounterLabel}"
+                   HorizontalOptions="Center" />
+
+            <!-- Progress bar — only shown when TotalRows is set -->
+            <VerticalStackLayout Spacing="6"
+                                 IsVisible="{Binding HasTotalRows}">
+
+              <Grid ColumnDefinitions="*,Auto">
+                <Label Grid.Column="0"
+                       Text="{Binding ProgressText}"
+                       FontFamily="MontserratMedium"
+                       FontSize="13"
+                       TextColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark={StaticResource DarkTextSecondary}}" />
+
+                <Label Grid.Column="1"
+                       Text="{Binding ProgressPercentage}"
+                       FontFamily="MontserratSemiBold"
+                       FontSize="13"
+                       TextColor="{StaticResource BrandGold}" />
+              </Grid>
+
+              <!-- Progress fill bar -->
+              <ProgressBar Progress="{Binding ProgressValue}"
+                     ProgressColor="{StaticResource BrandGold}"
+                     BackgroundColor="{AppThemeBinding Light=#E5E7EB, Dark=#374151}"
+                     HeightRequest="8" />
+
+            </VerticalStackLayout>
+
+            <!-- +/- buttons -->
+            <Grid ColumnDefinitions="*,*"
+                  ColumnSpacing="12"
+                  Margin="0,8,0,0">
+
+              <!-- Decrement -->
+              <Button Grid.Column="0"
+                      Text="−"
+                      Style="{StaticResource SecondaryButton}"
+                      FontSize="28"
+                      Command="{Binding DecrementCommand}" />
+
+              <!-- Increment -->
+              <Button Grid.Column="1"
+                      Text="+"
+                      Style="{StaticResource PrimaryButton}"
+                      FontSize="28"
+                      Command="{Binding IncrementCommand}" />
+
+            </Grid>
+
+            <!-- Undo & Reset -->
+            <Grid ColumnDefinitions="*,*"
+                  ColumnSpacing="15"
+                  Margin="0,0,0,0">
+
+              <!-- Undo Button -->
+              <Border Grid.Column="0"
+                      BackgroundColor="Transparent"
+                      HorizontalOptions="Center">
+                <Border.GestureRecognizers>
+                  <TapGestureRecognizer Command="{Binding UndoCommand}" />
+                </Border.GestureRecognizers>
+
+                <HorizontalStackLayout Spacing="6"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       Padding="10,8">
+                  <Image Source="undo.svg"
+                         HeightRequest="16"
+                         WidthRequest="16"
+                         VerticalOptions="Center">
+                    <Image.Behaviors>
+                      <toolkit:IconTintColorBehavior TintColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark=White}" />
+                    </Image.Behaviors>
+                  </Image>
+                  <Label Text="Undo"
+                         TextColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark=White}"
+                         FontFamily="MontserratBold"
+                         FontSize="12"
+                         VerticalOptions="Center" />
+                </HorizontalStackLayout>
+              </Border>
+
+
+              <!-- Reset Button -->
+              <Border Grid.Column="1"
+                      BackgroundColor="Transparent"
+                      HorizontalOptions="Center">
+                <Border.GestureRecognizers>
+                  <TapGestureRecognizer Command="{Binding ResetCommand}" />
+                </Border.GestureRecognizers>
+
+                <HorizontalStackLayout Spacing="6"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       Padding="10,8">
+                  <Image Source="reset.svg"
+                         HeightRequest="16"
+                         WidthRequest="16"
+                         VerticalOptions="Center">
+                    <Image.Behaviors>
+                      <toolkit:IconTintColorBehavior TintColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark=White}" />
+                    </Image.Behaviors>
+                  </Image>
+                  <Label Text="Reset"
+                         TextColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark=White}"
+                         FontFamily="MontserratBold"
+                         FontSize="12"
+                         VerticalOptions="Center" />
+                </HorizontalStackLayout>
+              </Border>
+
+            </Grid>
+
+          </VerticalStackLayout>
+
+        </Border>
+
+        <!-- ============================================ -->
+        <!-- NOTES CARD (only shown if project has notes) -->
+        <!-- ============================================ -->
+        <Border Padding="16"
+                Margin="0,16,0,0"
+                StrokeThickness="0"
+                BackgroundColor="{AppThemeBinding Light={StaticResource LightCardBackground}, Dark={StaticResource DarkCardBackground}}"
+                IsVisible="{Binding HasNotes}">
+
+          <Border.StrokeShape>
+            <RoundRectangle CornerRadius="12" />
+          </Border.StrokeShape>
+
+          <VerticalStackLayout Spacing="8">
+
+            <Label Text="📝 Notes"
+                   FontFamily="MontserratSemiBold"
+                   FontSize="14"
+                   TextColor="{AppThemeBinding Light={StaticResource LightTextPrimary}, Dark={StaticResource DarkTextPrimary}}" />
+
+            <Label Text="{Binding Notes}"
+                   FontFamily="MontserratRegular"
+                   FontSize="14"
+                   LineBreakMode="WordWrap"
+                   MaxLines="{Binding NotesMaxLines}"
+                   TextColor="{AppThemeBinding Light={StaticResource LightTextSecondary}, Dark={StaticResource DarkTextSecondary}}" />
+
+            <Label Text="{Binding NotesToggleText}"
+                   FontFamily="MontserratMedium"
+                   FontSize="14"
+                   TextColor="{StaticResource BrandGold}"
+                   IsVisible="{Binding NotesCanExpand}">
+              <Label.GestureRecognizers>
+                <TapGestureRecognizer Command="{Binding ToggleNotesCommand}" />
+              </Label.GestureRecognizers>
+            </Label>
+
+          </VerticalStackLayout>
+
+        </Border>
+
+        <!-- ============================================ -->
+        <!-- BOTTOM BUTTONS: Save Progress | End Session  -->
+        <!-- ============================================ -->
+        <Grid ColumnDefinitions="*,*"
+              ColumnSpacing="12"
+              Margin="0,24,0,32">
+
+          <!-- Save Progress — stays on page -->
+          <Button Grid.Column="0"
+                  Text="SAVE PROGRESS"
+                  Style="{StaticResource SecondaryButton}"
+                  Command="{Binding SaveProgressCommand}" />
+
+          <!-- End Session — saves + navigates back -->
+          <Button Grid.Column="1"
+                  Text="END SESSION"
+                  Style="{StaticResource PrimaryButton}"
+                  Command="{Binding EndSessionCommand}" />
+
+        </Grid>
+
+      </VerticalStackLayout>
+
+    </ScrollView>
+
+  </Grid>
+
+</ContentPage>

--- a/src/StitchTrack.MAUI/Views/ProjectCounterPage.xaml.cs
+++ b/src/StitchTrack.MAUI/Views/ProjectCounterPage.xaml.cs
@@ -1,0 +1,111 @@
+using StitchTrack.Application.ViewModels;
+
+namespace StitchTrack.MAUI.Views;
+
+/// <summary>
+/// Code-behind for ProjectCounterPage.
+/// Owns the session timer — the ViewModel handles all business logic.
+/// Timer tick updates the ViewModel which updates the UI via binding.
+/// </summary>
+[QueryProperty(nameof(ProjectId), "ProjectId")]
+// Timer is disposed in OnDisappearing — MAUI pages use lifecycle methods
+// instead of IDisposable since the framework controls their lifetime
+#pragma warning disable CA1001
+public partial class ProjectCounterPage : ContentPage
+#pragma warning restore CA1001
+{
+    private readonly ProjectCounterViewModel _viewModel;
+    private string _projectId = string.Empty;
+
+    // Timer lives here (MAUI layer) — ViewModel stays free of System.Timers
+    private System.Timers.Timer? _sessionTimer;
+    private TimeSpan _sessionDuration;
+
+    public ProjectCounterPage(ProjectCounterViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        BindingContext = _viewModel;
+
+        // Watch for session start/stop so we can run/stop the timer
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+
+        System.Diagnostics.Debug.WriteLine("✅ ProjectCounterPage initialized");
+    }
+
+    public string ProjectId
+    {
+        get => _projectId;
+        set
+        {
+            _projectId = value;
+            if (Guid.TryParse(value, out var projectId))
+            {
+                _viewModel.ProjectId = projectId;
+                System.Diagnostics.Debug.WriteLine($"📌 ProjectId set: {projectId}");
+            }
+        }
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadProjectAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+
+        // Always clean up the timer when leaving the page
+        StopTimer();
+        _sessionTimer?.Dispose();
+        _sessionTimer = null;
+    }
+
+    /// <summary>
+    /// Watches IsSessionRunning on the ViewModel and starts/stops the timer accordingly.
+    /// Keeps timer lifecycle in the Page where it belongs.
+    /// </summary>
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(ProjectCounterViewModel.IsSessionRunning)) return;
+
+        if (_viewModel.IsSessionRunning)
+            StartTimer();
+        else
+            StopTimer();
+    }
+
+    private void StartTimer()
+    {
+        if (_sessionTimer == null)
+        {
+            _sessionTimer = new System.Timers.Timer(1000);
+            _sessionTimer.Elapsed += OnTimerTick;
+        }
+
+        _sessionTimer.Start();
+        System.Diagnostics.Debug.WriteLine("⏱️ Session timer started");
+    }
+
+    private void StopTimer()
+    {
+        _sessionTimer?.Stop();
+        System.Diagnostics.Debug.WriteLine("⏹️ Session timer stopped");
+    }
+
+    /// <summary>
+    /// Fires every second — updates the ViewModel with the new elapsed time.
+    /// ViewModel formats and notifies the UI via binding.
+    /// </summary>
+    private void OnTimerTick(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _sessionDuration = _sessionDuration.Add(TimeSpan.FromSeconds(1));
+
+        // ViewModel update must happen on the main thread
+        MainThread.BeginInvokeOnMainThread(() =>
+            _viewModel.UpdateSessionTimer(_sessionDuration)
+        );
+    }
+}

--- a/src/StitchTrack.MAUI/Views/SingleProjectPage.xaml
+++ b/src/StitchTrack.MAUI/Views/SingleProjectPage.xaml
@@ -44,22 +44,6 @@
     </Grid>
 
     <!-- ============================================ -->
-    <!-- HEADER: Project Name                  -->
-    <!-- ============================================ -->
-    <Grid Grid.Row="1"
-          BackgroundColor="{AppThemeBinding Light={StaticResource LightAppBackground}, Dark={StaticResource DarkAppBackground}}"
-          HeightRequest="60"
-          Padding="20,15">
-
-      <!-- Project Name -->
-      <Label Text="{Binding ProjectName}"
-             Style="{StaticResource HeaderTitle}"
-             HorizontalOptions="Start"
-             VerticalOptions="Center" />
-
-    </Grid>
-
-    <!-- ============================================ -->
     <!-- SCROLLABLE CONTENT                           -->
     <!-- ============================================ -->
     <ScrollView Grid.Row="2">


### PR DESCRIPTION
- Add ProjectCounterPage with increment/decrement/undo/reset, progress bar, and collapsible notes
- Add ProjectCounterViewModel with session start/pause/end flow and save progress
- Add ISessionRepository and SessionRepository with Phase 1 + future stats page methods
- Wire ContinueCountingCommand in SingleProjectViewModel to navigate to ProjectCounterPage
- Fix EF concurrency error by adding GetByIdWithoutHistoryAsync to avoid CounterHistory tracking conflicts
- Fix UpdateAsync to skip Update() call on already-tracked entities
- Fix stale project count in list view by adding AsNoTracking() to GetActiveProjectsAsync and GetArchivedProjectsAsync
- Add UpdateCountAsync using ExecuteUpdateAsync to bypass change tracker for counter saves
- Detach stale CounterHistory entries in SessionRepository.SaveChangesAsync
- Register ProjectCounterPage, ProjectCounterViewModel and ISessionRepository in MauiProgram
- Register ProjectCounterPage route in AppShell